### PR TITLE
fix(test): disable flyway for tests

### DIFF
--- a/backend/src/test/resources/application-openapi-export.yaml
+++ b/backend/src/test/resources/application-openapi-export.yaml
@@ -8,3 +8,5 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: none
+  flyway:
+    enabled: false


### PR DESCRIPTION
as a 'temporary' workaround, we disabled flyway for our tests. we don't do integration tests anyway right now, and when we will, we'll probably use testcontainers
- disabled flyway for tests